### PR TITLE
update for php >=7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require" : {
-        "php": "^7.4.0",
+        "php": ">=7.4",
 	    "spiral/roadrunner": "^1.5"
     },
     "autoload": {


### PR DESCRIPTION
### Updated
- Update `composer.json` for php >=7.4, possibly php8

### Try to fix
- ubiquity-roadrunner is failing on Techempower benchmarks
see [last run build log](https://tfb-status.techempower.com/unzip/results.2021-01-18-10-23-39-324.zip/results/20210113214749/ubiquity-roadrunner/build/ubiquity-roadrunner.log)